### PR TITLE
Multi-target the library to NET4.0, NET4.6.1 and NETStandard2.0

### DIFF
--- a/SerialPortLib.sln
+++ b/SerialPortLib.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Serial", "Test.Serial\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerialPortLib.Tests", "SerialPortLib.Tests\SerialPortLib.Tests.csproj", "{7D5C40F9-8056-427E-9E06-13A161B00FB3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp.NetCore", "TestApp.NetCore\TestApp.NetCore.csproj", "{D5D595D2-58B5-4F26-ACCA-3DC11EEAA7C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,6 +27,10 @@ Global
 		{7D5C40F9-8056-427E-9E06-13A161B00FB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D5C40F9-8056-427E-9E06-13A161B00FB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D5C40F9-8056-427E-9E06-13A161B00FB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5D595D2-58B5-4F26-ACCA-3DC11EEAA7C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5D595D2-58B5-4F26-ACCA-3DC11EEAA7C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5D595D2-58B5-4F26-ACCA-3DC11EEAA7C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5D595D2-58B5-4F26-ACCA-3DC11EEAA7C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/SerialPortLib/SerialPortLib.csproj
+++ b/SerialPortLib/SerialPortLib.csproj
@@ -1,68 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8118C0B9-3B16-47AA-8B24-E5B15F429F78}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SerialPortLib</RootNamespace>
-    <AssemblyName>SerialPortLib</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <ReleaseVersion>1.0</ReleaseVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <!-- This project will output netstandard2.0 and net461 assemblies -->
+    <TargetFrameworks>netstandard2.0;net40;net461</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\SerialPortLib.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SerialPort.cs" />
-    <Compile Include="Events.cs" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="SerialPortStream" Version="2.2.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <ItemGroup>
-    <None Include="..\README.md">
-      <Link>README.md</Link>
-    </None>
-    <None Include="packages.config" />
+
+  <!-- Conditionally obtain references for the .NET Framework 4.0 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="NLog" Version="4.5.10" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c">
-      <HintPath>..\packages\NLog.4.5.10\lib\net40-client\NLog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Xml" />
+
+  <!-- Conditionally obtain references for the .NET Framework 4.6.1 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="NLog" Version="4.5.10" />
   </ItemGroup>
 </Project>

--- a/SerialPortLib/SerialPortLib.nuspec
+++ b/SerialPortLib/SerialPortLib.nuspec
@@ -21,11 +21,21 @@ Features
         <copyright>G-Labs</copyright>
         <tags>serial port</tags>
         <dependencies>
-            <dependency id="NLog" version="4.5.10" />
+            <group targetFramework="net40">
+                <dependency id="NLog" version="4.5.10" />
+            </group>
+
+            <group targetFramework="net461">
+                <dependency id="NLog" version="4.5.10" />
+            </group>
+
+            <group targetFramework="netstandard2.0">
+                <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" />
+                <dependency id="SerialPortStream" version="2.2.0" />
+            </group>
         </dependencies>
     </metadata>
     <files>
-        <file src="bin\Debug\SerialPortLib.dll" target="lib\SerialPortLib.dll" />
-        <file src="bin\Debug\SerialPortLib.xml" target="lib\SerialPortLib.xml" />
+        <file src="bin\Debug\**" target="lib" />
     </files>
 </package>

--- a/SerialPortLib/nuget_pack.ps1
+++ b/SerialPortLib/nuget_pack.ps1
@@ -14,4 +14,6 @@ if (-not ([string]::IsNullOrEmpty($versionStr))) {
 
   & nuget pack $root\$project\$project.compiled.nuspec
 }
-
+else {
+  Write-Host "Version string is empty, possibly dry run or APPVEYOR_REPO_TAG_NAME environment variable is not set"
+}

--- a/SerialPortLib/packages.config
+++ b/SerialPortLib/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NLog" version="4.5.10" targetFramework="net40-client" />
-</packages>

--- a/TestApp.NetCore/Program.cs
+++ b/TestApp.NetCore/Program.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NLog.Config;
+using NLog.Extensions.Logging;
+using NLog.Layouts;
+using NLog.Targets;
+using SerialPortLib;
+
+namespace TestApp.NetCore
+{
+    class Program
+    {
+        private static string defaultPort = "/dev/ttyUSB0";
+        private static SerialPortInput serialPort;
+
+        // NOTE: To disable debug output uncomment the following two lines
+        // NLog.LogLevel.Info;
+        private static NLog.LogLevel minLogLevel = NLog.LogLevel.Debug;
+
+        public static void Main(string[] args)
+        {
+            var servicesProvider = BuildDi();
+            using (servicesProvider as IDisposable)
+            {
+                serialPort = servicesProvider.GetRequiredService<SerialPortInput>();
+                serialPort.ConnectionStatusChanged += SerialPort_ConnectionStatusChanged;
+                serialPort.MessageReceived += SerialPort_MessageReceived;
+
+                while (true)
+                {
+                    Console.WriteLine("\nPlease enter serial to open (eg. \"COM7\" or \"/dev/ttyUSB0\" without double quotes),");
+                    Console.WriteLine("or enter \"QUIT\" to exit.\n");
+                    Console.Write("Port [{0}]: ", defaultPort);
+                    string port = Console.ReadLine();
+                    if (String.IsNullOrWhiteSpace(port))
+                        port = defaultPort;
+                    else
+                        defaultPort = port;
+
+                    // exit if the user enters "quit"
+                    if (port.Trim().ToLower().Equals("quit"))
+                        break;
+
+                    serialPort.SetPort(port, 115200);
+                    serialPort.Connect();
+
+                    Console.WriteLine("Waiting for serial port connection on {0}.", port);
+                    while (!serialPort.IsConnected)
+                    {
+                        Console.Write(".");
+                        Thread.Sleep(1000);
+                    }
+                    // This is a test message (ZWave protocol message for getting the nodes stored in the Controller)
+                    var testMessage = new byte[] { 0x01, 0x03, 0x00, 0x02, 0xFE };
+                    // Try sending some data if connected
+                    if (serialPort.IsConnected)
+                    {
+                        Console.WriteLine("\nConnected! Sending test message 5 times.");
+                        for (int s = 0; s < 5; s++)
+                        {
+                            Thread.Sleep(2000);
+                            Console.WriteLine("\nSEND [{0}]", (s + 1));
+                            serialPort.SendMessage(testMessage);
+                        }
+                    }
+                    Console.WriteLine("\nTest sequence completed, now disconnecting.");
+
+                    serialPort.Disconnect();
+                }
+            }
+        }
+
+        static void SerialPort_MessageReceived(object sender, MessageReceivedEventArgs args)
+        {
+            Console.WriteLine("Received message: {0}", BitConverter.ToString(args.Data));
+            // On every message received we send an ACK message back to the device
+            serialPort.SendMessage(new byte[] { 0x06 });
+        }
+
+        static void SerialPort_ConnectionStatusChanged(object sender, ConnectionStatusChangedEventArgs args)
+        {
+            Console.WriteLine("Serial port connection status = {0}", args.Connected);
+        }
+
+        private static IServiceProvider BuildDi()
+        {
+            return new ServiceCollection()
+                .AddTransient<SerialPortInput>()
+                .AddLogging(loggingBuilder =>
+                {
+                    // configure Logging with NLog
+                    loggingBuilder.ClearProviders();
+                    loggingBuilder.SetMinimumLevel(LogLevel.Trace);
+                    loggingBuilder.AddNLog(new LoggingConfiguration
+                    {
+                        LoggingRules =
+                        {
+                            new LoggingRule(
+                                "*",
+                                minLogLevel,
+                                new ConsoleTarget
+                                {
+                                    Layout = new SimpleLayout("${longdate} ${callsite} ${level} ${message} ${exception}")
+                                })
+                        }
+                    });
+                })
+                .BuildServiceProvider();
+        }
+    }
+}

--- a/TestApp.NetCore/TestApp.NetCore.csproj
+++ b/TestApp.NetCore/TestApp.NetCore.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SerialPortLib\SerialPortLib.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+      <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
+    </ItemGroup>
+
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2015
+image: Visual Studio 2017
 configuration: Debug
 before_build:
   - nuget restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,6 @@ test:
 after_test:
   - ps: .\SerialPortLib\nuget_pack.ps1
 artifacts:
-  - path: .\SerialPortLib\bin\Debug\SerialPortLib.dll
-    name: SerialPortLib
-    type: File
   - path: '*.nupkg'
     name: SerialPortLib nupkg
     type: NuGetPackage

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="../SerialPortLib/packages.config" />
-  <repository path="../Test.Serial/packages.config" />
-</repositories>


### PR DESCRIPTION
This should fix #7 and allow anybody to use the library in .Net Core and ASP.Net Core applications.
Also included .Net Core test application.