### PR TITLE
Make SetPort() taking into account changes in parameters baudRate, stopBits, stopBits, parity, parity, dataBits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ Thumbs.db
 *.userprefs
 .idea
 .riderModule.iml
+/.vs/SerialPortLib/DesignTimeBuild/.dtbcache.v2
+/.vs/ProjectSettings.json
+/.vs/VSWorkspaceState.json
+/.vs/slnx.sqlite

--- a/SerialPortLib/Properties/AssemblyInfo.cs
+++ b/SerialPortLib/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // È possibile specificare tutti i valori oppure impostare valori predefiniti per i numeri relativi alla revisione e alla build 
 // utilizzando l'asterisco (*) come descritto di seguito:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]

--- a/SerialPortLib/SerialPort.cs
+++ b/SerialPortLib/SerialPort.cs
@@ -202,17 +202,22 @@ namespace SerialPortLib
         /// <param name="dataBits">Databits.</param>
         public void SetPort(string portName, int baudRate = 115200, StopBits stopBits = StopBits.One, Parity parity = Parity.None, DataBits dataBits = DataBits.Eight)
         {
-            if (_portName != portName)
+            if (_portName != portName || _baudRate != baudRate || stopBits != _stopBits || parity != _parity || dataBits != _dataBits)
             {
-                // set to error so that the connection watcher will reconnect
-                // using the new port
-                gotReadWriteError = true;
+                // Change Parameters request
+                // Take into account immediately the new connection parameters
+                // (do not use the ConnectionWatcher, otherwise strange things will occurs !)
+                _portName = portName;
+                _baudRate = baudRate;
+                _stopBits = stopBits;
+                _parity = parity;
+                _dataBits = dataBits;
+                if (IsConnected)
+                {
+                    Connect();      // Take into account immediately the new connection parameters
+                }
+                LogDebug(string.Format("Port parameters changed (port name {0} / baudrate {1} / stopbits {2} / parity {3} / databits {4})", portName, baudRate, stopBits, parity, dataBits));
             }
-            _portName = portName;
-            _baudRate = baudRate;
-            _stopBits = stopBits;
-            _parity = parity;
-            _dataBits = dataBits;
         }
 
         /// <summary>


### PR DESCRIPTION
Make SetPort() to take into account changes in parameters baudRate, stopBits, stopBits, parity, parity, dataBits.
This pull request is originated by #18  Setting a new baudrate with SetPort(...) doesn't work