### PR TITLE
Added IsBackground = true | Fixing a hung process

### DIFF
--- a/SerialPortLib/SerialPort.cs
+++ b/SerialPortLib/SerialPort.cs
@@ -130,7 +130,7 @@ namespace SerialPortLib
                 Disconnect();
                 Open();
                 _connectionWatcherCts = new CancellationTokenSource();
-                _connectionWatcher = new Thread(ConnectionWatcherTask);
+                _connectionWatcher = new Thread(ConnectionWatcherTask) { IsBackground = true };
                 _connectionWatcher.Start(_connectionWatcherCts.Token);
             }
             return IsConnected;
@@ -265,7 +265,7 @@ namespace SerialPortLib
                     _gotReadWriteError = false;
                     // Start the Reader task
                     _readerCts = new CancellationTokenSource();
-                    _reader = new Thread(ReaderTask);
+                    _reader = new Thread(ReaderTask) { IsBackground = true };
                     _reader.Start(_readerCts.Token);
                     OnConnectionStatusChanged(new ConnectionStatusChangedEventArgs(true));
                 }


### PR DESCRIPTION
Fixed an issue where a parent thread was closed from which the `_connectionWatcher `and `_reader` child threads were started, and the child thread continued its work, resulting in a suspended state of one or more threads after the main form of the application UI was closed.
.
.
The problem became obvious in WinForms dot-net 7.0 when I created and configured several `SerialPortInput `objects on a child form, called `Connect `method for all of them, and then called `Disconnect `for all of them and closed first the child form and then the main form and the process remained hanging in Task Manager.